### PR TITLE
Load external links in widget loader

### DIFF
--- a/widget-loader.js
+++ b/widget-loader.js
@@ -59,6 +59,16 @@
                 document.head.appendChild(styleElement);
                 console.log('Styles injected');
             }
+
+            // Inject link elements (e.g., external stylesheets, fonts)
+            const links = doc.querySelectorAll('link[rel="stylesheet"], link[rel="preconnect"], link[rel="icon"], link[rel="preload"]');
+            links.forEach(link => {
+                const linkElement = document.createElement('link');
+                Array.from(link.attributes).forEach(attr => {
+                    linkElement.setAttribute(attr.name, attr.value);
+                });
+                document.head.appendChild(linkElement);
+            });
             
             // Remove script tags from body
             const scripts = doc.querySelectorAll('script');


### PR DESCRIPTION
## Summary
- Ensure widget loader copies `<link>` tags from fetched HTML so external styles and fonts load correctly.

## Testing
- `node --check widget-loader.js`
- `node --check widget-main.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c4b2a540832a8ce3d4ac331f548a